### PR TITLE
feat: add SEO module with schema and accessibility improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,21 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## Analytics y Search Console
+
+### ¿Qué es Google Analytics 4 (GA4) y para qué sirve?
+GA4 permite medir el tráfico y las acciones que realizan los usuarios en tu sitio. Con estos datos puedes entender qué secciones funcionan mejor y optimizar la conversión.
+
+**Configuración básica:**
+1. Crea una propiedad en [analytics.google.com](https://analytics.google.com).
+2. Genera un flujo web y copia el *ID de medición*.
+3. Inserta la etiqueta de GA4 en tu proyecto (por ejemplo, mediante un plugin o directamente en `app.vue`).
+
+### ¿Qué es Google Search Console y por qué lo necesitas?
+Search Console muestra cómo Google ve tu sitio. Sirve para monitorear el rendimiento en las búsquedas, detectar errores de indexación y enviar sitemaps.
+
+**Configuración básica:**
+1. Accede a [search.google.com/search-console](https://search.google.com/search-console).
+2. Añade tu dominio y verifica la propiedad (DNS recomendado).
+3. Envía el sitemap generado por Nuxt para que Google rastree tu contenido.

--- a/components/landing/AboutAdvisorSection.vue
+++ b/components/landing/AboutAdvisorSection.vue
@@ -5,7 +5,13 @@
         <h2 id="about-title" class="text-h5 text-sm-h4 mb-6 text-center">{{ about.heading }}</h2>
         <VRow align="center">
           <VCol cols="12" md="4" class="text-center mb-4 mb-md-0">
-            <VImg :src="about.photo" alt="Foto del asesor" max-width="250" class="rounded-circle mx-auto" />
+            <VImg
+              :src="about.photo"
+              alt="Foto del asesor"
+              max-width="250"
+              class="rounded-circle mx-auto"
+              loading="lazy"
+            />
           </VCol>
           <VCol cols="12" md="8">
             <p class="mb-4">{{ about.bio }}</p>

--- a/components/landing/HeroSection.vue
+++ b/components/landing/HeroSection.vue
@@ -1,9 +1,16 @@
 <template>
-  <section role="banner" class="py-12">
+  <section role="banner" aria-labelledby="hero-title" class="py-12">
     <slot>
-      <VImg :src="hero.image" :alt="hero.imageAlt" cover height="500" class="d-flex align-center">
+      <VImg
+        :src="hero.image"
+        :alt="hero.imageAlt"
+        cover
+        height="500"
+        class="d-flex align-center"
+        loading="lazy"
+      >
         <VContainer class="text-center text-white">
-          <h1 class="text-h4 text-sm-h2 font-weight-bold">{{ hero.title }}</h1>
+          <h1 id="hero-title" class="text-h4 text-sm-h2 font-weight-bold">{{ hero.title }}</h1>
           <p class="text-subtitle-1 text-sm-h5">{{ hero.subtitle }}</p>
           <VBtn
             color="secondary"

--- a/composables/useSEO.ts
+++ b/composables/useSEO.ts
@@ -1,0 +1,104 @@
+import { useHead } from '#imports'
+
+interface SEOOptions {
+  title?: string
+  description?: string
+  image?: string
+  keywords?: string[]
+  schema?: Record<string, any> | Record<string, any>[]
+}
+
+const defaultMeta: Required<Omit<SEOOptions, 'schema'>> = {
+  title: 'Asesor financiero en Costa Rica | Educación e inversión',
+  description:
+    'Asesoría financiera para costarricenses que desean invertir desde cero y alcanzar el retiro anticipado.',
+  image: 'https://placehold.co/1200x630.png',
+  keywords: [
+    'inversiones Costa Rica',
+    'asesor financiero',
+    'educación financiera',
+    'retiro anticipado',
+    'finanzas personales',
+  ],
+}
+
+const organizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Asesor Financiero CR',
+  url: 'https://example.com',
+  logo: 'https://placehold.co/250x250',
+  address: {
+    '@type': 'PostalAddress',
+    addressCountry: 'CR',
+  },
+}
+
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Malcolm Ugalde',
+  jobTitle: 'Asesor Financiero',
+  worksFor: {
+    '@type': 'Organization',
+    name: 'Asesor Financiero CR',
+  },
+}
+
+const serviceSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Asesoría financiera personalizada',
+  provider: { '@type': 'Person', name: 'Malcolm Ugalde' },
+  areaServed: 'CR',
+}
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: '¿Cuánto dinero necesito para empezar a invertir?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Puedes comenzar con montos pequeños desde $100.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: '¿Ofreces asesoría personalizada?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Sí, cada plan se adapta a tus objetivos.',
+      },
+    },
+  ],
+}
+
+export const defaultSchema = [organizationSchema, personSchema, serviceSchema, faqSchema]
+
+export function useSEO(options: SEOOptions = {}) {
+  const meta = { ...defaultMeta, ...options }
+  const schemaList = Array.isArray(options.schema) ? options.schema : defaultSchema
+
+  useHead({
+    title: meta.title,
+    meta: [
+      { name: 'description', content: meta.description },
+      { name: 'keywords', content: meta.keywords.join(', ') },
+      { property: 'og:title', content: meta.title },
+      { property: 'og:description', content: meta.description },
+      { property: 'og:image', content: meta.image },
+      { property: 'og:type', content: 'website' },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:title', content: meta.title },
+      { name: 'twitter:description', content: meta.description },
+      { name: 'twitter:image', content: meta.image },
+    ],
+    script: schemaList.map((s) => ({
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify(s),
+    })),
+  })
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -20,4 +20,18 @@ import AboutAdvisorSection from '@/components/landing/AboutAdvisorSection.vue'
 import TestimonialsSection from '@/components/landing/TestimonialsSection.vue'
 import FAQSection from '@/components/landing/FAQSection.vue'
 import FinalCTASection from '@/components/landing/FinalCTASection.vue'
+import { useSEO } from '@/composables/useSEO'
+
+useSEO({
+  title: 'Asesor financiero en Costa Rica | Invierte desde cero',
+  description:
+    'Aprende a invertir desde cero con asesoría financiera personalizada para lograr tu libertad financiera en Costa Rica.',
+  keywords: [
+    'inversiones Costa Rica',
+    'asesor financiero',
+    'educación financiera',
+    'retiro anticipado',
+    'finanzas personales',
+  ],
+})
 </script>


### PR DESCRIPTION
## Summary
- centralize meta tags and JSON-LD schema in `useSEO` composable
- enable lazy-loading and ARIA labeling in hero and about sections
- document basic GA4 and Search Console setup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b2a2e0cfe8832f95e61cc378a35a7f