### PR TITLE
feat: add trust quote section

### DIFF
--- a/components/landing/AboutAdvisorSection.vue
+++ b/components/landing/AboutAdvisorSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section aria-labelledby="about-title" class="py-10 bg-grey-lighten-4">
+  <section aria-labelledby="about-title" class="py-10">
     <slot>
       <VContainer class="py-12">
         <h2 id="about-title" class="text-h5 text-sm-h4 mb-6 text-center">{{ about.heading }}</h2>

--- a/components/landing/FAQSection.vue
+++ b/components/landing/FAQSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section aria-labelledby="faq-title" class="py-10 bg-grey-lighten-4">
+  <section aria-labelledby="faq-title" class="py-10">
     <slot>
       <VContainer class="py-12">
         <h2 id="faq-title" class="text-h5 text-sm-h4 mb-6 text-center">{{ faq.heading }}</h2>

--- a/components/landing/FinalCTASection.vue
+++ b/components/landing/FinalCTASection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section aria-labelledby="cta-title" class="py-12">
+  <section aria-labelledby="cta-title" class="py-12 bg-grey-lighten-4">
     <slot>
       <VContainer class="py-12 text-center">
         <h2 id="cta-title" class="text-h5 text-sm-h4 mb-4">{{ finalCTA.heading }}</h2>

--- a/components/landing/QuoteSection.vue
+++ b/components/landing/QuoteSection.vue
@@ -1,0 +1,30 @@
+<template>
+  <section class="py-8" aria-label="Mensaje de confianza sobre la modalidad del acompañamiento">
+    <v-container class="d-flex justify-center">
+      <v-responsive max-width="960">
+        <v-card :variant="props.variant" class="pa-6">
+          <blockquote class="text-h6 text-sm-h5 mb-0" aria-live="polite">
+            «No son cursos pregrabados ni programas impersonales de más de $1000 como tantos que hay allá afuera. El acompañamiento es real, humano, cercano y sincrónico.»
+          </blockquote>
+        </v-card>
+      </v-responsive>
+    </v-container>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { PropType } from 'vue'
+
+const props = defineProps({
+  variant: {
+    type: String as PropType<'elevated' | 'outlined' | 'tonal' | 'flat'>,
+    default: 'elevated',
+  },
+})
+</script>
+
+<style scoped>
+blockquote {
+  line-height: 1.6;
+}
+</style>

--- a/components/landing/QuoteSection.vue
+++ b/components/landing/QuoteSection.vue
@@ -1,30 +1,39 @@
 <template>
-  <section class="py-8" aria-label="Mensaje de confianza sobre la modalidad del acompañamiento">
-    <v-container class="d-flex justify-center">
-      <v-responsive max-width="960">
-        <v-card :variant="props.variant" class="pa-6">
-          <blockquote class="text-h6 text-sm-h5 mb-0" aria-live="polite">
-            «No son cursos pregrabados ni programas impersonales de más de $1000 como tantos que hay allá afuera. El acompañamiento es real, humano, cercano y sincrónico.»
-          </blockquote>
-        </v-card>
-      </v-responsive>
+  <section class="py-6 py-md-8" aria-label="Mensaje de confianza sobre la modalidad del acompañamiento">
+    <v-container>
+      <v-row justify="center">
+        <v-col cols="12" sm="11" md="10" lg="8">
+          <v-card :variant="variant" class="pa-4 pa-sm-6 pa-md-8">
+            <blockquote class="quote" aria-live="polite">
+              «No son cursos pregrabados ni programas impersonales de más de $1000 como tantos que hay allá afuera. El acompañamiento es real, humano, cercano y sincrónico.»
+            </blockquote>
+          </v-card>
+        </v-col>
+      </v-row>
     </v-container>
   </section>
 </template>
 
 <script setup lang="ts">
-import type { PropType } from 'vue'
-
 const props = defineProps({
-  variant: {
-    type: String as PropType<'elevated' | 'outlined' | 'tonal' | 'flat'>,
-    default: 'elevated',
-  },
-})
+  variant: { type: String, default: 'elevated' }
+});
 </script>
 
 <style scoped>
-blockquote {
+/* Tipografía y legibilidad responsive */
+.quote {
+  /* tamaños responsivos: h6 en móvil, h5 en >= md */
+  font-size: clamp(1rem, 2.5vw, 1.375rem); /* ~16px a ~22px */
   line-height: 1.6;
+  margin: 0;
+  text-wrap: pretty;
+  overflow-wrap: anywhere; /* evita desbordes en palabras largas */
+  hyphens: auto;
+}
+
+/* Ajustes visuales del card en mobile */
+:deep(.v-card) {
+  border-radius: 16px;
 }
 </style>

--- a/components/landing/QuoteSection.vue
+++ b/components/landing/QuoteSection.vue
@@ -15,9 +15,12 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps({
-  variant: { type: String, default: 'elevated' }
-});
+const props = defineProps<{
+  variant?: 'elevated' | 'flat' | 'text' | 'tonal' | 'outlined' | 'plain'
+}>()
+
+// Set default value separately
+const { variant = 'elevated' } = props
 </script>
 
 <style scoped>

--- a/components/landing/ServicesSection.vue
+++ b/components/landing/ServicesSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section aria-labelledby="services-title" class="py-10">
+  <section aria-labelledby="services-title" class="py-10 bg-grey-lighten-4">
     <slot>
       <VContainer class="py-12">
         <h2 id="services-title" class="text-h5 text-sm-h4 mb-6">{{ services.heading }}</h2>

--- a/components/landing/TestimonialsSection.vue
+++ b/components/landing/TestimonialsSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section aria-labelledby="testimonials-title" class="py-10">
+  <section aria-labelledby="testimonials-title" class="py-10 bg-grey-lighten-4">
     <slot>
       <VContainer class="py-12">
         <h2 id="testimonials-title" class="text-h5 text-sm-h4 mb-6 text-center">{{ testimonials.heading }}</h2>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,6 +3,7 @@
     <HeroSection />
     <ProblemSection />
     <SolutionSection />
+    <QuoteSection variant="outlined" />
     <ServicesSection />
     <AboutAdvisorSection />
     <TestimonialsSection />
@@ -15,6 +16,7 @@
 import HeroSection from '@/components/landing/HeroSection.vue'
 import ProblemSection from '@/components/landing/ProblemSection.vue'
 import SolutionSection from '@/components/landing/SolutionSection.vue'
+import QuoteSection from '@/components/landing/QuoteSection.vue'
 import ServicesSection from '@/components/landing/ServicesSection.vue'
 import AboutAdvisorSection from '@/components/landing/AboutAdvisorSection.vue'
 import TestimonialsSection from '@/components/landing/TestimonialsSection.vue'


### PR DESCRIPTION
## Summary
- add QuoteSection component for reusable trust quote card
- show quote between Solution and Services sections on landing page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b37a9c4284832f896647fe8e1f9285